### PR TITLE
Switch mimeType from ogg to webm

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -36,7 +36,7 @@ class AudioRecorder extends Widget {
 }
 
 let audioRecorder: any;
-const mimeType = "audio/ogg";
+const mimeType = "audio/webm";
 let saveFile: Function;
 let insertCodeSnippet = false;
 let insertCodeSnippetForFile: Function;

--- a/src/index.ts
+++ b/src/index.ts
@@ -266,7 +266,7 @@ namespace Private {
         var fileReader = new FileReader();
         const blob = audioRecorder.getBlob();
 
-        const file_extension = blob.type.split("/")[1];
+        const file_extension = blob.type.split("/")[1].split(";")[0];
 
         fileReader.readAsArrayBuffer(blob);
         fileReader.onload = () => {


### PR DESCRIPTION
Previously, MediaRecorder was complaining about not being able to record `audio/ogg`, which is why this extension isn't working. This fixes that issue.